### PR TITLE
Add #MATCH# case for check_results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,25 @@ target/
 
 # config files
 config.yaml
+
+# IDE project files and various temp files
+.tmp
+.sass-cache
+.idea
+.ropeproject
+*.*~*
+*.sublime-workspace
+
+# MacOS Files
+.DS_Store
+.AppleDouble
+.LSOverride
+.Spotlight-V100
+.Trashes
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ The `check_result` json content has some additional parameters that can be used 
     "key" : [ "#ALL#", obj1, obj2]
     ```
     checks that the result has exactly the two entries `obj1` and `obj2`, the order of these entries is not important.
+    * Lists starting with `"#MATCH#"` check that all the entries of the list respect the pattern of each corresponding object in the list. For instance, the template:
+    ```json
+    "key" : [ "#MATCH#", { "key2" : "value" }, { "key3" : "#r#val" }]
+    ```
+    checks that the result has exactly the two entries, and one result of the list is matching `{ "key2" : "value" }`, and another match `{ "key3" : "#r#val" } pattern`. The order of these entries is not important.
 
 One can also check the HTTP code returned by the endpoint by using `check_code`. By default it checks that the endpoint
 returns `200`. To check the return error message, use `check_message`, a good combination can be:

--- a/app/utils.py
+++ b/app/utils.py
@@ -175,6 +175,32 @@ def check_json(result, expectation, path="$", exit_on_error=False, skip_errors=F
                     iterations == len(res) and len(entries) == 0,
                     'The results in path "{}" do not match what expected'.format(path),
                     exit_on_error=exit_on_error)
+
+            # Check all entries are matching elements.
+            # It's a mix of PATTERN and ALL.
+            # Number of items must match number of expected results, and expected results must respect pattern.
+            elif len(exp) > 0 and pattern == "#MATCH#":
+                light_assert(
+                    len(res) == len(exp),
+                    u'The number of results in path "{}" does not match what expected (there were {} entries rather than {})'.format(path, len(res), len(exp)),
+                    exit_on_error=exit_on_error)
+
+                iterations = 0
+                entries = range(len(res))
+                while iterations < len(res):
+                    for idx in entries:
+                        no_err = check_json(res[iterations], exp[idx], path + "[{}]".format(idx + 1), exit_on_error=exit_on_error,
+                                            skip_errors=True)
+                        if no_err:
+                            entries.remove(idx)
+                            break
+                    iterations += 1
+
+                no_error = light_assert(
+                    iterations == len(res) and len(entries) == 0,
+                    'The results in path "{}" do not match what expected'.format(path),
+                    exit_on_error=exit_on_error)
+
         else:
             exp = unicode(exp)
             res = unicode(res)


### PR DESCRIPTION
The #MATCH# is a mix of #PATTERN# and #ALL#.
It check the number of results is matching number of expected results. It check also that each expected object have been found in results, and each result is matching an expected result.
