### PR TITLE
Add possibility to execute unauthenticated requests for one test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ auth:
   oauth_scope:
       - "https://www.googleapis.com/auth/userinfo.email"
 ```
+To override global configuration for one test case, you can set :
+```yaml
+- my.endpoint:
+  config:
+    auth:
+      email: "someone.else@somewhere.net"
+```
+with same parameters as auth.yaml.
+
+If you want to execute one test case without authentication, you can set:
+```yaml
+- my.endpoint:
+  config:
+    auth: null
+```
 
 See [Getting Started with Google Tasks API on Google App Engine](https://cloud.google.com/appengine/articles/python/getting_started_with_tasks_api) for more details.
 

--- a/app/default.py
+++ b/app/default.py
@@ -140,7 +140,7 @@ class CommandParser():
                 service = self.service
                 # change the auth temporarily
                 if 'config' in command:
-                    config = self.config
+                    config = dict(self.config)
                     service_config = self.scenario['service']
                     if 'auth' in command['config']:
                         for key, val in command['config']['auth'].iteritems():

--- a/app/default.py
+++ b/app/default.py
@@ -143,11 +143,14 @@ class CommandParser():
                     config = dict(self.config)
                     service_config = self.scenario['service']
                     if 'auth' in command['config']:
-                        for key, val in command['config']['auth'].iteritems():
-                            if isinstance(val, unicode) or isinstance(val, str):
-                                config['auth'][key] = self.eval_expr(val)
-                            else:
-                                config['auth'][key] = val
+                        if command['config']['auth']:
+                            for key, val in command['config']['auth'].iteritems():
+                                if isinstance(val, unicode) or isinstance(val, str):
+                                    config['auth'][key] = self.eval_expr(val)
+                                else:
+                                    config['auth'][key] = val
+                        else:
+                            config['auth'] = None
 
                     if 'service' in command['config']:
                         for key, val in command['config']['service'].iteritems():


### PR DESCRIPTION
If auth.yaml is defined, we can now execute one test case without authentication.
To do this, just set config/auth: null in test case
