### PR TITLE
Fix check_order when there are more than one criteria to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,11 @@ One can also check that values in a list are correctly sorted by using `check_or
 ```yaml
 - my_endpoint:
   check_order:
-    !expr items.*.date as list: desc
-    !expr items.*.name as list: asc
+    - !expr items.*.date as list: desc
+    - !expr items.*.name as list: asc
 ```
 checks that response items are sorted by date desc and by name asc.
+If there are multiple criteria, the second (and following) criteria is used in case of equality for the first criteria.
 
 One can also check the HTTP code returned by the endpoint by using `check_code`. By default it checks that the endpoint
 returns `200`. To check the return error message, use `check_message`, a good combination can be:

--- a/app/default.py
+++ b/app/default.py
@@ -480,13 +480,21 @@ class CommandParser():
                     match = self.expression_matcher.match(order)
                     raise RuntimeError("Expression {} for check_order is incorrect".format(match.group(1)))
 
-                elif isinstance(order, dict):
-                    for expr, direction in order.iteritems():
-                        # we have a list!
-                        match = self.expression_matcher.match(expr)
-                        if match:
-                            val = self.__parse_expression(match.group(1), container=result)
-                            check_order_values(val, direction, path=match.group(1), exit_on_error=self.exit_on_error)
+                elif isinstance(order, list):
+                    values = []
+                    directions = []
+                    paths = []
+                    for criteria in order:
+                        for expr, direction in criteria.iteritems():
+                            # we have a list!
+                            match = self.expression_matcher.match(expr)
+                            if match:
+                                val = self.__parse_expression(match.group(1), container=result)
+                                values.append(val)
+                                directions.append(direction)
+                                paths.append(match.group(1))
+
+                    check_order_values(values, directions, paths, exit_on_error=self.exit_on_error)
 
     def _parse_body(self, body):
         for key, val in body.iteritems():


### PR DESCRIPTION
If multiple criteria for check_order, use the first to check values. In case of equality, use the second criteria (and followings)
